### PR TITLE
Fix application icon path for packaged build

### DIFF
--- a/build_CSGPR.bat
+++ b/build_CSGPR.bat
@@ -50,6 +50,7 @@ pyinstaller --noconfirm --clean --windowed --noupx ^
   --collect-all parselmouth ^
   --collect-all i18n_pkg ^
   --collect-all csgpr ^
+  --add-data "icon.ico;." ^
   --icon="%ICON%" "%APP%"
 
 if errorlevel 1 (
@@ -65,6 +66,6 @@ echo   dist\CSGPR\CSGPR.exe
 
 echo.
 echo [Optional] Build single-file EXE (may trigger more antivirus flags):
-echo   pyinstaller --noconfirm --clean --onefile --windowed --noupx --name CSGPR --collect-all numpy --collect-all parselmouth --collect-all i18n_pkg --collect-all csgpr --icon="%ICON%" "%APP%"
+echo   pyinstaller --noconfirm --clean --onefile --windowed --noupx --name CSGPR --collect-all numpy --collect-all parselmouth --collect-all i18n_pkg --collect-all csgpr --add-data "icon.ico;." --icon="%ICON%" "%APP%"
 echo.
 pause

--- a/csgpr/app.py
+++ b/csgpr/app.py
@@ -2,15 +2,25 @@ from __future__ import annotations
 
 """Application entry point."""
 
+import os
 import sys
 
+from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QApplication
 
+from .constants import APP_ICON_PATH
 from .main_window import MainWindow
 
 
 def main() -> None:
     app = QApplication(sys.argv)
+
+    try:
+        if os.path.exists(APP_ICON_PATH):
+            app.setWindowIcon(QIcon(APP_ICON_PATH))
+    except Exception:  # pragma: no cover - environment specific
+        pass
+
     window = MainWindow()
     window.show()
     sys.exit(app.exec())

--- a/csgpr/constants.py
+++ b/csgpr/constants.py
@@ -2,8 +2,25 @@ from __future__ import annotations
 
 """Shared constants for the Chromatic Scale Generator PLUS!"""
 
+from pathlib import Path
+import sys
+
+
+def _base_dir() -> Path:
+    """Return the directory where bundled resources live.
+
+    When frozen via PyInstaller the resources are extracted to ``_MEIPASS``.
+    Otherwise we fall back to the project root (two levels above this file).
+    """
+
+    root = getattr(sys, "_MEIPASS", None)  # type: ignore[attr-defined]
+    if root:
+        return Path(root)
+    return Path(__file__).resolve().parent.parent
+
+
 APP_TITLE = "Chromatic Scale Generator PLUS! (REMASTERED)"
-APP_ICON_PATH = r"C:\\Users\\Administrator\\Downloads\\CSGR\\icon.ico"  # optional
+APP_ICON_PATH = str(_base_dir() / "icon.ico")
 DEFAULT_SR = 48000
 NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
 OCTAVES = list(range(1, 9))


### PR DESCRIPTION
## Summary
- resolve the window icon path dynamically so it works from source and frozen builds
- apply the icon to the QApplication and bundle the asset with PyInstaller

## Testing
- python -m compileall csgpr

------
https://chatgpt.com/codex/tasks/task_e_68e846e5da94832e8e4ff92c5a1acb42