### PR TITLE
Add wiki and tutorial links to help options

### DIFF
--- a/csgpr/constants.py
+++ b/csgpr/constants.py
@@ -27,3 +27,9 @@ OCTAVES = list(range(1, 9))
 MAX_SEMITONES = 128
 MAX_GAP_SEC = 5.0
 DISCORD_INVITE = "https://discord.gg/pe6J4FbcCU"
+PROJECT_WIKI_URL = (
+    "https://github.com/immalloy/Chromatic-Scale-Generator-Plus-Remastered/wiki"
+)
+PROJECT_TUTORIAL_URL = (
+    "https://github.com/immalloy/Chromatic-Scale-Generator-Plus-Remastered/wiki/Tutorial"
+)

--- a/csgpr/main_window.py
+++ b/csgpr/main_window.py
@@ -6,8 +6,8 @@ import os
 import subprocess
 from pathlib import Path
 
-from PySide6.QtCore import Slot
-from PySide6.QtGui import QAction, QIcon
+from PySide6.QtCore import QUrl, Slot
+from PySide6.QtGui import QAction, QDesktopServices, QIcon
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -38,6 +38,8 @@ from .constants import (
     MAX_SEMITONES,
     NOTE_NAMES,
     OCTAVES,
+    PROJECT_TUTORIAL_URL,
+    PROJECT_WIKI_URL,
 )
 from .dialogs import CreditsDialog
 from .generation import GenerateWorker
@@ -197,10 +199,16 @@ class MainWindow(QMainWindow):
         footer_row = QHBoxLayout()
         self.footer = QLabel(T(self.lang, "Footer"))
         self.footer.setObjectName("Footer")
+        self.wiki_btn = QPushButton(T(self.lang, "Wiki"))
+        self.wiki_btn.setObjectName("LinkButton")
+        self.tutorial_btn = QPushButton(T(self.lang, "Tutorial"))
+        self.tutorial_btn.setObjectName("LinkButton")
         self.credits_btn = QPushButton(T(self.lang, "Credits"))
         self.credits_btn.setObjectName("LinkButton")
         footer_row.addWidget(self.footer, 1)
         footer_row.addStretch(1)
+        footer_row.addWidget(self.wiki_btn, 0)
+        footer_row.addWidget(self.tutorial_btn, 0)
         footer_row.addWidget(self.credits_btn, 0)
 
         outer = QVBoxLayout(central)
@@ -211,6 +219,16 @@ class MainWindow(QMainWindow):
         outer.addLayout(footer_row)
 
         help_menu = self.menuBar().addMenu(T(self.lang, "&Help"))
+        act_wiki = QAction(T(self.lang, "Wiki"), self)
+        act_wiki.triggered.connect(self.open_wiki)
+        help_menu.addAction(act_wiki)
+
+        act_tutorial = QAction(T(self.lang, "Tutorial"), self)
+        act_tutorial.triggered.connect(self.open_tutorial)
+        help_menu.addAction(act_tutorial)
+
+        help_menu.addSeparator()
+
         act_credits = QAction(T(self.lang, "Credits"), self)
         act_credits.triggered.connect(self.show_credits)
         help_menu.addAction(act_credits)
@@ -225,6 +243,8 @@ class MainWindow(QMainWindow):
         self.generate_btn.clicked.connect(self.start_generation)
         self.cancel_btn.clicked.connect(self.cancel_generation)
         self.open_out_btn.clicked.connect(self.open_output_folder_clicked)
+        self.wiki_btn.clicked.connect(self.open_wiki)
+        self.tutorial_btn.clicked.connect(self.open_tutorial)
         self.credits_btn.clicked.connect(self.show_credits)
 
         self.worker: GenerateWorker | None = None
@@ -265,11 +285,23 @@ class MainWindow(QMainWindow):
         self.generate_btn.setText(T(self.lang, "Generate Chromatic"))
         self.cancel_btn.setText(T(self.lang, "Cancel"))
         self.open_out_btn.setText(T(self.lang, "Open Output Folder"))
+        self.wiki_btn.setText(T(self.lang, "Wiki"))
+        self.tutorial_btn.setText(T(self.lang, "Tutorial"))
         self.credits_btn.setText(T(self.lang, "Credits"))
         self.footer.setText(T(self.lang, "Footer"))
 
         self.menuBar().clear()
         help_menu = self.menuBar().addMenu(T(self.lang, "&Help"))
+        act_wiki = QAction(T(self.lang, "Wiki"), self)
+        act_wiki.triggered.connect(self.open_wiki)
+        help_menu.addAction(act_wiki)
+
+        act_tutorial = QAction(T(self.lang, "Tutorial"), self)
+        act_tutorial.triggered.connect(self.open_tutorial)
+        help_menu.addAction(act_tutorial)
+
+        help_menu.addSeparator()
+
         act_credits = QAction(T(self.lang, "Credits"), self)
         act_credits.triggered.connect(self.show_credits)
         help_menu.addAction(act_credits)
@@ -371,6 +403,12 @@ class MainWindow(QMainWindow):
     def show_credits(self) -> None:
         dialog = CreditsDialog(self.lang, self)
         dialog.exec()
+
+    def open_wiki(self) -> None:
+        QDesktopServices.openUrl(QUrl(PROJECT_WIKI_URL))
+
+    def open_tutorial(self) -> None:
+        QDesktopServices.openUrl(QUrl(PROJECT_TUTORIAL_URL))
 
     @Slot()
     def start_generation(self) -> None:

--- a/i18n_pkg/lang_bn.py
+++ b/i18n_pkg/lang_bn.py
@@ -22,6 +22,8 @@ STRINGS = {
     "Open Output Folder": "আউটপুট ফোল্ডার খুলুন",
     "Logs will appear here…": "লগ এখানে দেখাবে...",
     "Credits": "ক্রেডিট",
+    "Wiki": "উইকি",
+    "Tutorial": "টিউটোরিয়াল",
     "&Help": "&হেল্প",
     "Folder not found.": "ফোল্ডার পাওয়া যায়নি।",
     "Need at least 1.wav in this folder.": "এই ফোল্ডারে অন্তত 1.wav দরকার।",

--- a/i18n_pkg/lang_en.py
+++ b/i18n_pkg/lang_en.py
@@ -21,6 +21,8 @@ STRINGS = {
     "Open Output Folder": "Open Output Folder",
     "Logs will appear here…": "Logs will appear here…",
     "Credits": "Credits",
+    "Wiki": "Wiki",
+    "Tutorial": "Tutorial",
     "&Help": "&Help",
 
     "Folder not found.": "Folder not found.",

--- a/i18n_pkg/lang_es.py
+++ b/i18n_pkg/lang_es.py
@@ -21,6 +21,8 @@ STRINGS = {
     "Open Output Folder": "Abrir carpeta de salida",
     "Logs will appear here…": "Los mensajes aparecerán aquí…",
     "Credits": "Créditos",
+    "Wiki": "Wiki",
+    "Tutorial": "Tutorial",
     "&Help": "&Ayuda",
 
     "Folder not found.": "Carpeta no encontrada.",

--- a/i18n_pkg/lang_fr.py
+++ b/i18n_pkg/lang_fr.py
@@ -22,6 +22,8 @@ STRINGS = {
     "Open Output Folder": "Ouvrir le dossier de sortie",
     "Logs will appear here…": "Les journaux s'affichent ici...",
     "Credits": "Credits",
+    "Wiki": "Wiki",
+    "Tutorial": "Tutoriel",
     "&Help": "&Aide",
     "Folder not found.": "Dossier introuvable.",
     "Need at least 1.wav in this folder.": "Il faut au moins 1.wav dans ce dossier.",

--- a/i18n_pkg/lang_hi.py
+++ b/i18n_pkg/lang_hi.py
@@ -22,6 +22,8 @@ STRINGS = {
     "Open Output Folder": "आउटपुट फ़ोल्डर खोलें",
     "Logs will appear here…": "लॉग यहाँ दिखेंगे...",
     "Credits": "श्रेय",
+    "Wiki": "विकि",
+    "Tutorial": "ट्यूटोरियल",
     "&Help": "&मदद",
     "Folder not found.": "फ़ोल्डर नहीं मिला।",
     "Need at least 1.wav in this folder.": "इस फ़ोल्डर में कम से कम 1.wav चाहिए।",

--- a/i18n_pkg/lang_ja.py
+++ b/i18n_pkg/lang_ja.py
@@ -22,6 +22,8 @@ STRINGS = {
     "Open Output Folder": "出力フォルダを開く",
     "Logs will appear here…": "ログはここに表示されます...",
     "Credits": "クレジット",
+    "Wiki": "Wiki",
+    "Tutorial": "チュートリアル",
     "&Help": "&ヘルプ",
     "Folder not found.": "フォルダが見つかりません。",
     "Need at least 1.wav in this folder.": "このフォルダに 1.wav が必要です。",

--- a/i18n_pkg/lang_ko.py
+++ b/i18n_pkg/lang_ko.py
@@ -22,6 +22,8 @@ STRINGS = {
     "Open Output Folder": "출력 폴더 열기",
     "Logs will appear here…": "로그가 여기에 표시됩니다...",
     "Credits": "크레딧",
+    "Wiki": "위키",
+    "Tutorial": "튜토리얼",
     "&Help": "&도움말",
     "Folder not found.": "폴더를 찾을 수 없습니다.",
     "Need at least 1.wav in this folder.": "이 폴더에는 최소한 1.wav가 필요합니다.",

--- a/i18n_pkg/lang_pt_br.py
+++ b/i18n_pkg/lang_pt_br.py
@@ -21,6 +21,8 @@ STRINGS = {
     "Open Output Folder": "Abrir pasta de saída",
     "Logs will appear here…": "Os registros aparecem aqui…",
     "Credits": "Créditos",
+    "Wiki": "Wiki",
+    "Tutorial": "Tutorial",
     "&Help": "&Ajuda",
 
     "Folder not found.": "Pasta não encontrada.",

--- a/i18n_pkg/lang_ru.py
+++ b/i18n_pkg/lang_ru.py
@@ -22,6 +22,8 @@ STRINGS = {
     "Open Output Folder": "Открыть папку вывода",
     "Logs will appear here…": "Логи будут здесь...",
     "Credits": "Благодарности",
+    "Wiki": "Вики",
+    "Tutorial": "Учебник",
     "&Help": "&Справка",
     "Folder not found.": "Папка не найдена.",
     "Need at least 1.wav in this folder.": "В папке нужен хотя бы 1.wav.",

--- a/i18n_pkg/lang_zh.py
+++ b/i18n_pkg/lang_zh.py
@@ -22,6 +22,8 @@ STRINGS = {
     "Open Output Folder": "打开输出文件夹",
     "Logs will appear here…": "日志显示在这里...",
     "Credits": "致谢",
+    "Wiki": "Wiki",
+    "Tutorial": "教程",
     "&Help": "&帮助",
     "Folder not found.": "未找到文件夹。",
     "Need at least 1.wav in this folder.": "此文件夹至少需要 1.wav。",


### PR DESCRIPTION
## Summary
- add Help menu actions that open the project wiki and tutorial, and surface matching footer buttons
- store wiki URLs in constants so links stay consistent across the app
- localize the new Wiki and Tutorial labels across all supported languages

## Testing
- python -m compileall csgpr i18n_pkg

------
codex only imported the files for me :3