### PR TITLE
Improve light theme appearance

### DIFF
--- a/csgpr/dialogs.py
+++ b/csgpr/dialogs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Standalone Qt dialogs used by the application."""
 
-from PySide6.QtCore import QUrl
+from PySide6.QtCore import QUrl, Qt
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
     QDialog,
@@ -25,6 +25,7 @@ class CreditsDialog(QDialog):
 
         self.setWindowTitle(T(self.lang, "Credits"))
         self.setMinimumWidth(420)
+        self.setAttribute(Qt.WA_StyledBackground, True)
 
         layout = QVBoxLayout(self)
         text = QLabel(T(self.lang, "CreditsText"))

--- a/csgpr/main_window.py
+++ b/csgpr/main_window.py
@@ -120,7 +120,8 @@ class MainWindow(QMainWindow):
         self.lang_combo.setCurrentIndex(self.lang_combo.findData("en"))
 
         row = 0
-        cfg_layout.addWidget(QLabel(T(self.lang, "Sample folder")), row, 0)
+        self.sample_folder_label = QLabel(T(self.lang, "Sample folder"))
+        cfg_layout.addWidget(self.sample_folder_label, row, 0)
         folder_row = QHBoxLayout()
         folder_row.addWidget(self.path_edit, 1)
         folder_row.addWidget(self.browse_btn, 0)
@@ -130,19 +131,23 @@ class MainWindow(QMainWindow):
         cfg_layout.addWidget(self.warn_label, row, 0, 1, 2)
         row += 1
 
-        cfg_layout.addWidget(QLabel(T(self.lang, "Starting note")), row, 0)
+        self.starting_note_label = QLabel(T(self.lang, "Starting note"))
+        cfg_layout.addWidget(self.starting_note_label, row, 0)
         cfg_layout.addWidget(self.note_combo, row, 1)
         row += 1
 
-        cfg_layout.addWidget(QLabel(T(self.lang, "Starting octave")), row, 0)
+        self.starting_octave_label = QLabel(T(self.lang, "Starting octave"))
+        cfg_layout.addWidget(self.starting_octave_label, row, 0)
         cfg_layout.addWidget(self.octave_combo, row, 1)
         row += 1
 
-        cfg_layout.addWidget(QLabel(T(self.lang, "Semitone range")), row, 0)
+        self.semitone_range_label = QLabel(T(self.lang, "Semitone range"))
+        cfg_layout.addWidget(self.semitone_range_label, row, 0)
         cfg_layout.addWidget(self.range_spin, row, 1)
         row += 1
 
-        cfg_layout.addWidget(QLabel(T(self.lang, "Gap (seconds)")), row, 0)
+        self.gap_label = QLabel(T(self.lang, "Gap (seconds)"))
+        cfg_layout.addWidget(self.gap_label, row, 0)
         cfg_layout.addWidget(self.gap_spin, row, 1)
         row += 1
 
@@ -159,13 +164,16 @@ class MainWindow(QMainWindow):
         row += 1
 
         appearance_row = QHBoxLayout()
-        appearance_row.addWidget(QLabel("Theme:"))
+        self.theme_label = QLabel(T(self.lang, "Theme:"))
+        appearance_row.addWidget(self.theme_label)
         appearance_row.addWidget(self.mode_combo)
         appearance_row.addSpacing(12)
-        appearance_row.addWidget(QLabel("Accent:"))
+        self.accent_label = QLabel(T(self.lang, "Accent:"))
+        appearance_row.addWidget(self.accent_label)
         appearance_row.addWidget(self.accent_combo)
         appearance_row.addSpacing(12)
-        appearance_row.addWidget(QLabel("Language:"))
+        self.language_label = QLabel(T(self.lang, "Language:"))
+        appearance_row.addWidget(self.language_label)
         appearance_row.addWidget(self.lang_combo)
         appearance_row.addStretch(1)
         cfg_layout.addLayout(appearance_row, row, 0, 1, 2)
@@ -272,6 +280,11 @@ class MainWindow(QMainWindow):
         self.setWindowTitle(APP_TITLE)
         self.cfg_group.setTitle(T(self.lang, "Configuration"))
         self.run_group.setTitle(T(self.lang, "Run"))
+        self.sample_folder_label.setText(T(self.lang, "Sample folder"))
+        self.starting_note_label.setText(T(self.lang, "Starting note"))
+        self.starting_octave_label.setText(T(self.lang, "Starting octave"))
+        self.semitone_range_label.setText(T(self.lang, "Semitone range"))
+        self.gap_label.setText(T(self.lang, "Gap (seconds)"))
         self.browse_btn.setText(T(self.lang, "Browse…"))
         self.path_edit.setPlaceholderText(
             T(self.lang, "Select a folder containing 1.wav, 2.wav, ...")
@@ -285,6 +298,9 @@ class MainWindow(QMainWindow):
         self.generate_btn.setText(T(self.lang, "Generate Chromatic"))
         self.cancel_btn.setText(T(self.lang, "Cancel"))
         self.open_out_btn.setText(T(self.lang, "Open Output Folder"))
+        self.theme_label.setText(T(self.lang, "Theme:"))
+        self.accent_label.setText(T(self.lang, "Accent:"))
+        self.language_label.setText(T(self.lang, "Language:"))
         self.wiki_btn.setText(T(self.lang, "Wiki"))
         self.tutorial_btn.setText(T(self.lang, "Tutorial"))
         self.credits_btn.setText(T(self.lang, "Credits"))

--- a/csgpr/styles.py
+++ b/csgpr/styles.py
@@ -34,36 +34,38 @@ PALETTES: dict[PaletteKey, Palette] = {
         muted="#9A9A9A",
     ),
     ("light", "blue"): dict(
-        bg="#F7F7FA",
+        bg="#F4F6FB",
         panel="#FFFFFF",
-        text="#1B1B1B",
-        sub="#5A5A5A",
+        text="#202124",
+        sub="#596072",
         field="#FFFFFF",
-        border="#D7D7DD",
+        border="#D2D6E5",
         accent="#2D7CF3",
-        accent2="#5AA1FF",
-        warn="#B00020",
-        muted="#6F6F77",
+        accent2="#4D90FE",
+        warn="#B3261E",
+        muted="#6F7383",
     ),
     ("light", "pink"): dict(
-        bg="#FDF7FA",
+        bg="#FBF6FA",
         panel="#FFFFFF",
-        text="#1B1B1B",
-        sub="#7B5163",
+        text="#251723",
+        sub="#7A4D63",
         field="#FFFFFF",
-        border="#E6D6DE",
-        accent="#FF5AA1",
-        accent2="#FF7EB9",
-        warn="#B00020",
-        muted="#6F6F77",
+        border="#E3D0DA",
+        accent="#F44A91",
+        accent2="#FF7FBF",
+        warn="#B3261E",
+        muted="#8A6F7B",
     ),
 }
 
 
 def build_stylesheet(mode: str, accent: str) -> str:
     palette = PALETTES[(mode, accent)]
+    highlight_text = "white" if mode == "dark" else palette["text"]
     return f"""
         QMainWindow {{ background: {palette['bg']}; }}
+        QWidget {{ color: {palette['text']}; }}
         QGroupBox {{
             color: {palette['text']};
             border: 1px solid {palette['border']};
@@ -72,16 +74,35 @@ def build_stylesheet(mode: str, accent: str) -> str:
             padding-top: 12px;
             background: {palette['panel']};
         }}
+        QGroupBox::title {{
+            subcontrol-origin: margin;
+            left: 10px;
+            padding: 0 4px;
+            color: {palette['sub']};
+            font-weight: 600;
+        }}
         QLabel, QCheckBox, QStatusBar, QSpinBox, QDoubleSpinBox, QComboBox, QLineEdit {{
             color: {palette['text']};
             font-size: 14px;
         }}
-        QLineEdit, QSpinBox, QDoubleSpinBox, QComboBox, QTextEdit {{
+        QLineEdit, QSpinBox, QDoubleSpinBox, QComboBox, QTextEdit, QPlainTextEdit {{
             background: {palette['field']};
             border: 1px solid {palette['border']};
             border-radius: 8px;
             padding: 6px;
             color: {palette['text']};
+            selection-background-color: {palette['accent2']};
+            selection-color: {highlight_text};
+        }}
+        QLineEdit:focus, QSpinBox:focus, QDoubleSpinBox:focus, QComboBox:focus, QTextEdit:focus, QPlainTextEdit:focus {{
+            border: 1px solid {palette['accent']};
+        }}
+        QComboBox QAbstractItemView {{
+            background: {palette['panel']};
+            border: 1px solid {palette['border']};
+            color: {palette['text']};
+            selection-background-color: {palette['accent2']};
+            selection-color: {highlight_text};
         }}
         QPushButton {{
             background: {palette['accent']};
@@ -91,6 +112,8 @@ def build_stylesheet(mode: str, accent: str) -> str:
             color: white;
             font-weight: 600;
         }}
+        QPushButton:hover {{ background: {palette['accent2']}; }}
+        QPushButton:pressed {{ background: {palette['accent']}; }}
         QPushButton:disabled {{ background: {palette['border']}; color: {palette['muted']}; }}
         QProgressBar {{
             background: {palette['field']};
@@ -101,6 +124,46 @@ def build_stylesheet(mode: str, accent: str) -> str:
             height: 18px;
         }}
         QProgressBar::chunk {{ border-radius: 8px; margin: 1px; background: {palette['accent2']}; }}
+        QStatusBar {{
+            background: {palette['panel']};
+            color: {palette['sub']};
+            border-top: 1px solid {palette['border']};
+        }}
+        QStatusBar::item {{ border: none; }}
+        QMenuBar {{
+            background: {palette['panel']};
+            color: {palette['text']};
+            border-bottom: 1px solid {palette['border']};
+        }}
+        QMenuBar::item {{
+            background: transparent;
+            padding: 4px 12px;
+            margin: 0 4px;
+            border-radius: 6px;
+        }}
+        QMenuBar::item:selected {{ background: {palette['accent2']}; color: {highlight_text}; }}
+        QMenu {{
+            background: {palette['panel']};
+            color: {palette['text']};
+            border: 1px solid {palette['border']};
+        }}
+        QMenu::item {{ padding: 6px 24px; border-radius: 4px; }}
+        QMenu::item:selected {{ background: {palette['accent2']}; color: {highlight_text}; }}
+        QDialog, QMessageBox {{
+            background: {palette['panel']};
+            color: {palette['text']};
+        }}
+        QDialog QLabel, QMessageBox QLabel {{ color: {palette['text']}; }}
+        QDialog QPushButton, QMessageBox QPushButton {{
+            padding: 8px 14px;
+            border-radius: 8px;
+        }}
+        QToolTip {{
+            background: {palette['panel']};
+            color: {palette['text']};
+            border: 1px solid {palette['border']};
+            padding: 6px 8px;
+        }}
         #Footer {{ color: {palette['sub']}; font-size: 12px; padding: 8px 0; }}
         #WarnLabel {{ color: {palette['warn']}; font-size: 12px; }}
         #LinkButton {{ background: transparent; color: {palette['accent']}; border: none; text-decoration: underline; padding: 0px; font-weight: 600; }}


### PR DESCRIPTION
## Summary
- refresh the light palettes to improve contrast and harmonize accent colors
- expand the shared stylesheet so menus, dialogs, and inputs inherit light theme styling
- ensure the credits dialog opts into stylesheet backgrounds for consistent theming

## Testing
- python -m compileall csgpr

------
my pc doesnt let me do direct git help