### PR TITLE
Fix log append cursor move for PySide6

### DIFF
--- a/csgpr/main_window.py
+++ b/csgpr/main_window.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 from PySide6.QtCore import QUrl, Slot
-from PySide6.QtGui import QAction, QDesktopServices, QIcon
+from PySide6.QtGui import QAction, QDesktopServices, QIcon, QTextCursor
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -502,7 +502,7 @@ class MainWindow(QMainWindow):
     @Slot(str)
     def append_log(self, text: str) -> None:
         self.log.append(text)
-        self.log.moveCursor(self.log.textCursor().End)
+        self.log.moveCursor(QTextCursor.End)
 
     @Slot()
     def on_worker_finished(self) -> None:


### PR DESCRIPTION
## Summary
- import `QTextCursor` and use its `End` constant when moving the log cursor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e885086aa8832ebe2e3d9ff300ae6d