### PR TITLE
Ensure low notes use explicit pitch tier points

### DIFF
--- a/csgpr/generation.py
+++ b/csgpr/generation.py
@@ -152,9 +152,7 @@ class GenerateWorker(QThread):
                     self._emit("  • " + T(self.lang, "normalized"))
 
                 if self.pitched:
-                    snapshot = None
-                    if target_frequency < 60.0:
-                        snapshot = snd.values.copy()
+                    duration = float(snd.get_total_duration())
                     manipulation = parselmouth.praat.call(
                         snd,
                         "To Manipulation",
@@ -167,9 +165,32 @@ class GenerateWorker(QThread):
                     )
                     parselmouth.praat.call(
                         pitch_tier,
-                        "Formula",
-                        f"{target_frequency}",
+                        "Remove points between",
+                        snd.xmin,
+                        snd.xmax,
                     )
+                    start_time = float(snd.xmin)
+                    end_time = float(snd.xmax)
+                    parselmouth.praat.call(
+                        pitch_tier,
+                        "Add point",
+                        start_time,
+                        target_frequency,
+                    )
+                    if duration > 0.0 and end_time > start_time:
+                        parselmouth.praat.call(
+                            pitch_tier,
+                            "Add point",
+                            end_time,
+                            target_frequency,
+                        )
+                    else:
+                        parselmouth.praat.call(
+                            pitch_tier,
+                            "Add point",
+                            start_time + 1e-6,
+                            target_frequency,
+                        )
                     parselmouth.praat.call(
                         [pitch_tier, manipulation], "Replace pitch tier"
                     )


### PR DESCRIPTION
## Summary
- rebuild the generated pitch tier for every note to guarantee constant tuning
- add explicit pitch points for the start and end of the clip so very low notes are tuned correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e886faef44832eba179d7c89beee07