### PR TITLE
Bump version to 4.0.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 *Stuff is still being fixed btw :D*
 
-![Version](https://img.shields.io/badge/version-3.1.3-pink?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-4.0.0--beta-pink?style=for-the-badge)
 ![Python](https://img.shields.io/badge/Python-3.10%2B-3776AB?style=for-the-badge\&logo=python)
 ![License](https://img.shields.io/badge/License-GPLv3-green?style=for-the-badge)
 ![Build](https://img.shields.io/badge/Build-PyInstaller-lightgrey?style=for-the-badge)

--- a/i18n_pkg/meta.py
+++ b/i18n_pkg/meta.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-APP_VERSION: str = "3.1.3"
+APP_VERSION: str = "4.0.0-beta"
 RELEASE_YEAR: int = 2025 #cmon how did i forget THIS
 RELEASE_MONTH: int = 10  # October, I forgot shit
 


### PR DESCRIPTION
## Summary
- update the application metadata to report version 4.0.0-beta
- refresh the README version badge to display 4.0.0-beta

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb1791c724832ebaa0277e812ce607