### PR TITLE
Ensure splash assets bundled in Windows builds

### DIFF
--- a/build_CSGPR.bat
+++ b/build_CSGPR.bat
@@ -50,6 +50,7 @@ pyinstaller --noconfirm --clean --windowed --noupx ^
   --collect-all parselmouth ^
   --collect-all i18n_pkg ^
   --collect-all csgpr ^
+  --add-data "assets;assets" ^
   --add-data "icon.ico;." ^
   --icon="%ICON%" "%APP%"
 
@@ -66,6 +67,6 @@ echo   dist\CSGPR\CSGPR.exe
 
 echo.
 echo [Optional] Build single-file EXE (may trigger more antivirus flags):
-echo   pyinstaller --noconfirm --clean --onefile --windowed --noupx --name CSGPR --collect-all numpy --collect-all parselmouth --collect-all i18n_pkg --collect-all csgpr --add-data "icon.ico;." --icon="%ICON%" "%APP%"
+echo   pyinstaller --noconfirm --clean --onefile --windowed --noupx --name CSGPR --collect-all numpy --collect-all parselmouth --collect-all i18n_pkg --collect-all csgpr --add-data "assets;assets" --add-data "icon.ico;." --icon="%ICON%" "%APP%"
 echo.
 pause


### PR DESCRIPTION
## Summary
- bundle the assets directory when building the Windows executable so splash variants resolve at runtime
- update the optional onefile command hint to match the main build configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb25dc097c832e8289f98fe21d2ed2